### PR TITLE
Use contact.fatiando.org for Slack invite

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -103,7 +103,7 @@ html_context = {
         (
             '<i class="fab fa-slack fa-lg"></i>',
             "Slack chat group",
-            "https://join.slack.com/t/fatiando/shared_invite/enQtNzY4NDQ3ODQwNDk4LTc5MTU5OWNkNTczMDY4NjcyNjcyZTU0Y2I3MDQ0NWUwMmEzMTBkNmVjNTExMGZkMjA0YzM1OGYyMzZlMDk3YTU",
+            "http://contact.fatiando.org",
         ),
         (
             '<i class="fab fa-twitter fa-lg"></i>',

--- a/index.rst
+++ b/index.rst
@@ -249,7 +249,7 @@ Contacting Us
       </div>
       <div class="col-sm-4">
          <h2><i class="fab fa-slack fa-2x"></i></h2>
-         Hop on to our <a href="https://join.slack.com/t/fatiando/shared_invite/enQtNzY4NDQ3ODQwNDk4LTc5MTU5OWNkNTczMDY4NjcyNjcyZTU0Y2I3MDQ0NWUwMmEzMTBkNmVjNTExMGZkMjA0YzM1OGYyMzZlMDk3YTU">chat room on Slack</a>
+         Hop on to our <a href="http://contact.fatiando.org">chat room on Slack</a>
          where you can ask questions, leave comments, and reach out to users and
          developers.
       </div>


### PR DESCRIPTION
I setup the subdomain to forward to our slack invite so we have a more
stable domain name that we can update if we change the slack invite (or
move to another service).