### PR TITLE
Implement the old docs redirects through CI instead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
             echo "<meta http-equiv=\"Refresh\" content=\"0;url=https://legacy.fatiando.org\"/>" > _build/html/${version}/index.html
           done
 
+      - name: Print a directory tree of the generated HTML for debugging
+        run: tree _build/html
+
       - name: Push to fatiando.github.io
         if: success() && github.event_name == 'push'
         # Don't use tags: https://julienrenaux.fr/2019/12/20/github-actions-security-risk/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Build the website
         run: make all
 
+      - name: Setup redirects to legacy.fatiando.org
+        run: |
+          for version in v0.1 v0.2 v0.3 v0.4 v0.5 dev
+          do
+            mkdir _build/html/${version}
+            echo "<meta http-equiv=\"Refresh\" content=\"0;url=https://legacy.fatiando.org\"/>" > _build/html/${version}/index.html
+          done
+
       - name: Push to fatiando.github.io
         if: success() && github.event_name == 'push'
         # Don't use tags: https://julienrenaux.fr/2019/12/20/github-actions-security-risk/

--- a/dev/index.rst
+++ b/dev/index.rst
@@ -1,2 +1,0 @@
-.. meta::
-    :http-equiv=Refresh: 0;url=https://legacy.fatiando.org

--- a/index.rst
+++ b/index.rst
@@ -514,9 +514,3 @@ and the `source code archive on Github <https://github.com/fatiando/fatiando>`__
 The library will remain archived and usable for the foreseeable future.
 To get a sense for the reasoning behind the choice to abandon ``fatiando``, please read
 `this blog post <http://www.leouieda.com/blog/future-of-fatiando.html>`__.
-
-.. toctree::
-    :hidden:
-
-    v0.5/index.rst
-    dev/index.rst

--- a/v0.5/index.rst
+++ b/v0.5/index.rst
@@ -1,2 +1,0 @@
-.. meta::
-    :http-equiv=Refresh: 0;url=https://legacy.fatiando.org


### PR DESCRIPTION
Having the pages built by sphinx fills the HTMLs with a bunch of useless
stuff. Much better to build the redirection pages directly from the CI
script.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
