### PR TITLE
Minor tweaks to authors card style

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -150,30 +150,28 @@ The maintainers are the ones responsible for leading the projects, merging
 changes, making releases, and more.
 
 <div class="row gy-3">
-<div class="col-6 col-sm-3">
+<div class="col-4 col-sm-3 col-md-2 gx-2 d-flex align-items-stretch">
   <div class="card">
     <img class="card-img-top" src="https://github.com/santisoler.png">
     <div class="card-body">
-      <h4 class="card-title fs-5">
+      <h4 class="card-title fs-6">
         Santiago Soler
       </h4>
       <p class="card-text text-muted fs-6">
         <a href="https://github.com/santisoler">@santisoler</a>
-        on <i class="fab fa-github" title="GitHub"></i>
       </p>
     </div>
   </div>
 </div>
-<div class="col-6 col-sm-3">
+<div class="col-4 col-sm-3 col-md-2 gx-2 d-flex align-items-stretch">
   <div class="card">
     <img class="card-img-top" src="https://github.com/leouieda.png">
     <div class="card-body">
-      <h4 class="card-title fs-5">
+      <h4 class="card-title fs-6">
         Leonardo Uieda
       </h4>
       <p class="card-text text-muted fs-6">
         <a href="https://github.com/leouieda">@leouieda</a>
-        on <i class="fab fa-github" title="GitHub"></i>
       </p>
     </div>
   </div>

--- a/conf.py
+++ b/conf.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 AUTHORS_BASE_URL = "https://raw.githubusercontent.com/fatiando/{}/{}/AUTHORS.md"
 AUTHOR_HTML_CARD = """
-<div class="col-4 col-sm-3 col-md-2 gx-2">
+<div class="col-4 col-sm-3 col-md-2 gx-2 d-flex align-items-stretch">
   <div class="card">
     <img
         class="card-img-top"
@@ -23,7 +23,6 @@ AUTHOR_HTML_CARD = """
       </h4>
       <p class="card-text text-muted fs-6">
         <a href="https://github.com/{gh_handle}">@{gh_handle}</a>
-        on <i class="fab fa-github" title="GitHub"></i>
       </p>
     </div>
   </div>


### PR DESCRIPTION
Make sure they're all the same height, remove the excessive GitHub logo,
and make the maintainers cards match the authors cards.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
