### PR TITLE
Fix horizontal gutters on authors cards

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -149,8 +149,8 @@ authorship to those involved in our projects.
 The maintainers are the ones responsible for leading the projects, merging
 changes, making releases, and more.
 
-<div class="row gy-3">
-<div class="col-4 col-sm-3 col-md-2 gx-2 d-flex align-items-stretch">
+<div class="row gy-3 gx-2">
+<div class="col-4 col-sm-3 col-md-2 d-flex align-items-stretch">
   <div class="card">
     <img class="card-img-top" src="https://github.com/santisoler.png">
     <div class="card-body">

--- a/conf.py
+++ b/conf.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 AUTHORS_BASE_URL = "https://raw.githubusercontent.com/fatiando/{}/{}/AUTHORS.md"
 AUTHOR_HTML_CARD = """
-<div class="col-4 col-sm-3 col-md-2 gx-2 d-flex align-items-stretch">
+<div class="col-4 col-sm-3 col-md-2 d-flex align-items-stretch">
   <div class="card">
     <img
         class="card-img-top"
@@ -47,7 +47,7 @@ def authors_cards(package, main_branch="master"):
         HTML snippet for generating the authors cards of the selected package.
     """
     authors = get_authors(package, main_branch=main_branch)
-    html_snippet = '<div class="row gy-3">\n'
+    html_snippet = '<div class="row gy-3 gx-2">\n'
     for author in authors:
         full_name, gh_handle = author[:]
         avatar_url = get_avatar(gh_handle)


### PR DESCRIPTION
The gutters `gx-2` were being applied to the `col` elements, which
resulted in the cards being misaligned with the rest of the text. Apply
the gutters to the `row` element instead to fix this.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
