### PR TITLE
Avoid capturing trailing slashes from authors' GitHub handles

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -98,7 +98,7 @@ def _get_authors(authors_md):
     """
     Get authors' name and GitHub handle from AUTHORS.md content
     """
-    regex_pattern = r"\[(.+?)\]\((?:https://github.com/)(.+?)\)"
+    regex_pattern = r"\[(.+?)\]\((?:https://github.com/)(.+?)/?\)"
     _authors = re.findall(regex_pattern, authors_md)
     authors = []
     for author in _authors:


### PR DESCRIPTION
Avoid capturing trailing slashes on authors' GitHub handles when parsing
the `AUTHORS.md` files.

Related to fatiando/pooch#279

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
