### PR TITLE
Setup URL forwarding with plain HTML files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,14 +35,6 @@ jobs:
       - name: Set the CNAME file for our custom domain
         run: echo "www.fatiando.org" > _build/html/CNAME
 
-      - name: Setup redirects to legacy.fatiando.org
-        run: |
-          for version in v0.1 v0.2 v0.3 v0.4 v0.5 dev
-          do
-            mkdir _build/html/${version}
-            echo "<meta http-equiv=\"Refresh\" content=\"0;url=https://legacy.fatiando.org\"/>" > _build/html/${version}/index.html
-          done
-
       - name: Print a directory tree of the generated HTML for debugging
         run: tree -a _build/html
 

--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,6 @@ linkcheck:
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
+
 serve: html
 	python serve.py

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ your browser. To stop the server, type `Control + C`.
 * We use [Bootstrap 5.1](https://getbootstrap.com/docs/5.1/getting-started/introduction/)
   (just the CSS, not the Javascript components).
 
+### Forwarding
+
+We use the HTML files in the `forward` folder to redirect to other domains.
+This is not ideal but our DNS-based forwarding doesn't work with HTTPS (if you
+know a way around this, please let us know!).
+
+The files are copied to the output folder (`forward/dev/ -> _build/html/dev`
+which is served as `fatiando.org/dev`).
+To add a forward, create a new folder with an `index.html` similar to the ones
+we already include.
+
+**Use only for long and difficult to type URLs.**
+
 ## Deployment
 
 Pushing changes to [fatiando/website](https://github.com/fatiando/website)

--- a/community/index.md
+++ b/community/index.md
@@ -31,7 +31,7 @@ chat:
 <li>
 
 <i class="fa-li fab fa-slack fa-fw"></i>
-[Slack][slack]: where most conversation happens about meetings, events,
+<a href="/slack">Slack</a>: where most conversation happens about meetings, events,
 questions, etc.
 
 </li>
@@ -102,5 +102,4 @@ repository.
 [contrib]: https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
 [community-repo]: https://github.com/fatiando/community
 [gh]: https://github.com/fatiando
-[slack]: http://contact.fatiando.org
 [notes]: https://github.com/fatiando/community

--- a/conf.py
+++ b/conf.py
@@ -126,7 +126,7 @@ html_short_title = ""
 html_logo = "_static/fatiando-logo-background.png"
 html_favicon = "_static/favicon.png"
 html_static_path = ["_static"]
-html_extra_path = []
+html_extra_path = ["forward"]
 html_use_smartypants = True
 html_permalinks = False
 pygments_style = "default"
@@ -159,7 +159,7 @@ html_context = {
         (
             "fab fa-slack",
             "Slack",
-            "http://contact.fatiando.org",
+            "/slack",
         ),
         (
             "fab fa-twitter",

--- a/contact/index.md
+++ b/contact/index.md
@@ -13,7 +13,7 @@ Your input is welcome and appreciated.
 <i class="fab fa-slack fa-4x"></i>
 <h2 class="no-top-margin">Questions</h2>
 
-Hop on to our [chat room on Slack][slack] where you can **ask questions**,
+Hop on to our <a href="/slack">chat room on Slack</a> where you can **ask questions**,
 leave comments, and reach out to users and developers.
 
 </div>
@@ -41,5 +41,4 @@ we post **news and updates** about the project.
 [linkedin]: https://www.linkedin.com/company/fatiando
 [twitter]: https://twitter.com/fatiandoaterra
 [gh]: https://github.com/fatiando
-[bug-report]: https://github.com/fatiando/community/blob/main/CONTRIBUTING.md#reporting-a-bug
-[slack]: https://join.slack.com/t/fatiando/shared_invite/enQtNzY4NDQ3ODQwNDk4LTc5MTU5OWNkNTczMDY4NjcyNjcyZTU0Y2I3MDQ0NWUwMmEzMTBkNmVjNTExMGZkMjA0YzM1OGYyMzZlMDk3YTU
+[bug-report]: https://github.com/fatiando/community/blob/main/CONTRIBUTING.md

--- a/forward/calendar/index.html
+++ b/forward/calendar/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0;url=https://calendar.google.com/calendar/embed?src=2brp0bfvui24atsvb0ridafk50%40group.calendar.google.com"/>

--- a/forward/dev/index.html
+++ b/forward/dev/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0;url=https://legacy.fatiando.org"/>

--- a/forward/good-first-issues/index.html
+++ b/forward/good-first-issues/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0;url=https://github.com/search?q=org%3Afatiando+label%3A%22good+first+issue%22+is%3Aopen+is%3Aissue"/>

--- a/forward/slack/index.html
+++ b/forward/slack/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0;url=https://join.slack.com/t/fatiando/shared_invite/enQtNzY4NDQ3ODQwNDk4LTc5MTU5OWNkNTczMDY4NjcyNjcyZTU0Y2I3MDQ0NWUwMmEzMTBkNmVjNTExMGZkMjA0YzM1OGYyMzZlMDk3YTU"/>

--- a/forward/v0.1/index.html
+++ b/forward/v0.1/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0;url=https://legacy.fatiando.org"/>

--- a/forward/v0.2/index.html
+++ b/forward/v0.2/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0;url=https://legacy.fatiando.org"/>

--- a/forward/v0.3/index.html
+++ b/forward/v0.3/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0;url=https://legacy.fatiando.org"/>

--- a/forward/v0.4/index.html
+++ b/forward/v0.4/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0;url=https://legacy.fatiando.org"/>

--- a/forward/v0.5/index.html
+++ b/forward/v0.5/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="Refresh" content="0;url=https://legacy.fatiando.org"/>


### PR DESCRIPTION
We were using subdomain forwarding (calendar.fatiando.org) for some hard
to remember URLs. This unfortunately doesn't work with HTTPS, leading to
some broken links and ugly warnings from browsers about potential
danger. Replace those with a simple HTML redirection structure in
subfolders. For example, `fatiando.org/calendar` now redirects to the
Google calendar link. Same for `fatiando.org/slack` and
`fatiando.org/good-first-issue`. There are instructions in the README
for adding new forwards.
A caveat is that we now have to be careful with the subfolders we create
here. But that's probably not going to be a problem since this website
is intentionally not very elaborate (it links to other resources).

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
