### PR TITLE
Remove the Google Analytics tracking script

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -39,20 +39,7 @@
   <meta property="og:site_name" content="{{ project }}">
   <meta property="og:image" content="{{ base_url }}/_static/{{ logo }}">
   <meta property="og:description" content="{{ description }}">
-
-  <!-- Google Analytics tracking code -->
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new
-          Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-38125837-1', 'auto', {'storage': 'none'});
-    ga('set', 'anonymizeIp', true);
-    ga('send', 'pageview');
-  </script>
-
+  
   <!-- Plausible analytics for anonymous usage statistics -->
   <script defer data-domain="fatiando.org" src="https://plausible.io/js/plausible.js"></script>
 


### PR DESCRIPTION
We’ve decided to stick with Plausible from now on so we can remove
the old Google Analytics script.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Related to fatiando/community#46



**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
