### PR TITLE
Make a sphinx extension for fetching authors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ we already include.
 
 **Use only for long and difficult to type URLs.**
 
+## Sphinx extensions
+
+We implement some custom sphinx extensions for adding content to our website.
+All live under the `sphinx_extensions` folder of this repository:
+
+* `sphinx_extensions.authors`: Defines the `fatiando-authors` directive which
+  gets a list of project authors from the `AUTHORS.md` file in that project's
+  GitHub repository.
+
+All extensions are distributed under the MIT license.
+See [`sphinx_extensions/LICENSE.txt`](https://github.com/fatiando/website/blob/main/sphinx_extensions/LICENSE.txt).
+
 ## Deployment
 
 Pushing changes to [fatiando/website](https://github.com/fatiando/website)

--- a/about/index.md
+++ b/about/index.md
@@ -13,7 +13,6 @@ project's Brazilian origins and ambitious initial goals to model the whole
 planet.
 ```
 
-
 ## Who we are
 
 Fatiando tools are developed by **working geoscientists and community
@@ -22,8 +21,8 @@ volunteers** from across the globe.
 ### Authors
 
 The [GitHub repositories][gh] for each project contain `AUTHORS.md` files which
-list everyone involved:
-
+list everyone involved.
+These are the people listed in those files, in alphabetical order of last name:
 
 <ul class="nav nav-pills mb-3" id="authors-tab" role="tablist">
   <li class="nav-item" role="presentation">
@@ -90,6 +89,22 @@ list everyone involved:
     Boule
     </button>
   </li>
+  <li class="nav-item" role="presentation">
+    <button
+        class="nav-link"
+        id="authors-ensaio-tab"
+        data-bs-toggle="pill"
+        data-bs-target="#authors-ensaio"
+        type="button"
+        role="tab"
+        aria-controls="authors-ensaio"
+        aria-selected="true"
+        aria-label="Ensaio"
+    >
+    <i class="fa fa-users"></i>
+    Ensaio
+    </button>
+  </li>
 </ul>
 <div class="tab-content" id="authors-tabContent">
   <div
@@ -99,7 +114,7 @@ list everyone involved:
       aria-labelledby="authors-harmonica-tab"
   >
 
-```{include} harmonica-authors.md
+```{fatiando-authors} harmonica
 ```
 
   </div>
@@ -110,7 +125,7 @@ list everyone involved:
       aria-labelledby="authors-verde-tab"
   >
 
-```{include} verde-authors.md
+```{fatiando-authors} verde
 ```
 
   </div>
@@ -121,7 +136,7 @@ list everyone involved:
       aria-labelledby="authors-pooch-tab"
   >
 
-```{include} pooch-authors.md
+```{fatiando-authors} pooch
 ```
 
   </div>
@@ -132,7 +147,19 @@ list everyone involved:
       aria-labelledby="authors-boule-tab"
   >
 
-```{include} boule-authors.md
+```{fatiando-authors} boule
+:branch: master
+```
+
+  </div>
+  <div
+      class="tab-pane fade"
+      id="authors-ensaio"
+      role="tabpanel"
+      aria-labelledby="authors-ensaio-tab"
+  >
+
+```{fatiando-authors} ensaio
 ```
 
   </div>
@@ -153,12 +180,12 @@ changes, making releases, and more.
 <div class="col-4 col-sm-3 col-md-2 d-flex align-items-stretch">
   <div class="card">
     <img class="card-img-top" src="https://github.com/santisoler.png">
-    <div class="card-body">
-      <h4 class="card-title fs-6">
+    <div class="card-body text-center">
+      <p class="card-title fw-bold fs-6">
         Santiago Soler
-      </h4>
+      </p>
       <p class="card-text text-muted fs-6">
-        <a href="https://github.com/santisoler">@santisoler</a>
+        (<a href="https://github.com/santisoler">@santisoler</a>)
       </p>
     </div>
   </div>
@@ -166,12 +193,12 @@ changes, making releases, and more.
 <div class="col-4 col-sm-3 col-md-2 gx-2 d-flex align-items-stretch">
   <div class="card">
     <img class="card-img-top" src="https://github.com/leouieda.png">
-    <div class="card-body">
-      <h4 class="card-title fs-6">
+    <div class="card-body text-center">
+      <p class="card-title fw-bold fs-6">
         Leonardo Uieda
-      </h4>
+      </p>
       <p class="card-text text-muted fs-6">
-        <a href="https://github.com/leouieda">@leouieda</a>
+        (<a href="https://github.com/leouieda">@leouieda</a>)
       </p>
     </div>
   </div>

--- a/conf.py
+++ b/conf.py
@@ -1,6 +1,7 @@
 """
 Configuration for building the website with Sphinx.
 """
+import sys
 import re
 import datetime
 import subprocess
@@ -8,106 +9,13 @@ from requests import get
 from pathlib import Path
 
 
-AUTHORS_BASE_URL = "https://raw.githubusercontent.com/fatiando/{}/{}/AUTHORS.md"
-AUTHOR_HTML_CARD = """
-<div class="col-4 col-sm-3 col-md-2 d-flex align-items-stretch">
-  <div class="card">
-    <img
-        class="card-img-top"
-        src="{avatar_url}"
-        alt="Profile picture of {full_name}"
-    >
-    <div class="card-body">
-      <h4 class="card-title fs-6">
-          {full_name}
-      </h4>
-      <p class="card-text text-muted fs-6">
-        <a href="https://github.com/{gh_handle}">@{gh_handle}</a>
-      </p>
-    </div>
-  </div>
-</div>
-"""
+# Need this so the authors extension can be imported
+sys.path.append(".")
 
-
-def authors_cards(package, main_branch="master"):
-    """
-    Generate the html snippet for the authors cards of each package
-
-    Parameters
-    ----------
-    package : str
-        Name of the Fatiando a Terra package.
-    main_branch : str (optional)
-        Name of the main branch of the package. Default to ``"master"``.
-
-    Returns
-    -------
-    html_snippet : string
-        HTML snippet for generating the authors cards of the selected package.
-    """
-    authors = get_authors(package, main_branch=main_branch)
-    html_snippet = '<div class="row gy-3 gx-2">\n'
-    for author in authors:
-        full_name, gh_handle = author[:]
-        avatar_url = get_avatar(gh_handle)
-        html_snippet += AUTHOR_HTML_CARD.format(
-            gh_handle=gh_handle, full_name=full_name, avatar_url=avatar_url
-        )
-    html_snippet += "</div>"
-    return html_snippet
-
-
-def get_avatar(gh_handle):
-    """
-    Returns url avatar picture of GitHub user
-
-    If the picture is not availabe, returns url to a placeholder.
-    """
-    gh_avatar_url = f"https://github.com/{gh_handle}.png"
-    status_code = get(gh_avatar_url).status_code
-    if status_code == 404:
-        return "/_static/avatar-placeholder.jpg"
-    return gh_avatar_url
-
-
-def get_authors(package, main_branch="master"):
-    """
-    Returns a dict with information about the author of the package
-
-    Parameters
-    ----------
-    package : str
-        Name of the Fatiando a Terra package.
-    main_branch : str (optional)
-        Name of the main branch of the package. Default to ``"master"``.
-
-    Returns
-    -------
-    authors : list
-        List of tuples. Each tuple contains the ``full_name`` and the
-        ``github_handle`` of each user.
-    """
-    authors_md_url = AUTHORS_BASE_URL.format(package, main_branch)
-    markdown = get(authors_md_url).text
-    authors = _get_authors(markdown)
-    return authors
-
-
-def _get_authors(authors_md):
-    """
-    Get authors' name and GitHub handle from AUTHORS.md content
-    """
-    regex_pattern = r"\[(.+?)\]\((?:https://github.com/)(.+?)/?\)"
-    _authors = re.findall(regex_pattern, authors_md)
-    authors = []
-    for author in _authors:
-        full_name, gh_handle = author[:]
-        authors.append((full_name, gh_handle))
-    return authors
-
-
-extensions = ["myst_parser"]
+extensions = [
+    "myst_parser",
+    "sphinx_extensions.authors",
+]
 
 # Sphinx project configuration
 exclude_patterns = ["_build", "README.md", "LICENSE.md"]
@@ -130,14 +38,6 @@ html_extra_path = ["forward"]
 html_use_smartypants = True
 html_permalinks = False
 pygments_style = "default"
-
-# Generate cards with the authors of each project
-FATIANDO_PACKAGES = "pooch verde harmonica boule".split()
-for package in FATIANDO_PACKAGES:
-    html_snippet = authors_cards(package)
-    authors_file = Path("about") / f"{package}-authors.md"
-    with open(authors_file, "w") as f:
-        f.write(html_snippet)
 
 # Ignore the default theme and define everything through our own template.
 # These variables are passed to the templates in _templates/

--- a/sphinx_extensions/LICENSE.txt
+++ b/sphinx_extensions/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright 2022 The Fatiando a Terra Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sphinx_extensions/authors/__init__.py
+++ b/sphinx_extensions/authors/__init__.py
@@ -20,7 +20,7 @@ __version__ = "0.1.0"
 
 def _get_avatar(handle):
     """
-    Returns url avatar picture of GitHub user
+    Returns the url to the avatar picture of GitHub user
 
     If the picture is not available, returns url to a placeholder.
     """

--- a/sphinx_extensions/authors/__init__.py
+++ b/sphinx_extensions/authors/__init__.py
@@ -1,0 +1,140 @@
+"""
+Sphinx extension for inserting the authors of each package on the website.
+
+Based on:
+
+* sphinx-contributors (https://github.com/dgarcia360/sphinx-contributors) by
+  David Garcia (@dgarcia360), distributed under the MIT license.
+* sphinx-pannels (https://github.com/executablebooks/sphinx-panels) by
+  Executable Books, distributed under the MIT license.
+"""
+import re
+from pathlib import Path
+
+import requests
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+
+__version__ = "0.1.0"
+
+
+def _get_avatar(handle):
+    """
+    Returns url avatar picture of GitHub user
+
+    If the picture is not available, returns url to a placeholder.
+    """
+    avatar_url = f"https://github.com/{handle}.png"
+    if requests.get(avatar_url).status_code != 200:
+        avatar_url = "/_static/avatar-placeholder.jpg"
+    return avatar_url
+
+
+def _parse_authors_file(package, branch):
+    """
+    Returns a dict with information about the author of the package
+
+    Parameters
+    ----------
+    package : str
+        Name of the Fatiando a Terra package.
+
+    Returns
+    -------
+    authors : list
+        List of tuples. Each tuple contains the ``full_name`` and the
+        ``github_handle`` of each user.
+    """
+    response = requests.get(
+        f"https://raw.githubusercontent.com/fatiando/{package}/{branch}/AUTHORS.md",
+    )
+    response.raise_for_status()
+    markdown = response.text
+    authors = re.findall(r"\[(.+?)\]\((?:https://github.com/)(.+?)/?\)", markdown)
+    return authors
+
+
+class AuthorsDirective(Directive):
+    """
+    The fatiando-authors directive.
+    """
+
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    option_spec = {
+        "exclude": directives.unchanged,
+        "branch": directives.unchanged,
+    }
+
+    def run(self):
+        exclude = self.options.get("exclude", "").split(",")
+        branch = self.options.get("branch", "main")
+        package = self.arguments[0]
+
+        authors = _parse_authors_file(package, branch)
+
+        col_classes = "col-4 col-sm-3 col-md-2 d-flex align-items-stretch".split()
+        row_classes = "row gy-3 gx-2".split()
+        # Use is_div=True in our containers to stop docutils inserting the
+        # "container" class. Based on code from sphinx-panels.
+        row = nodes.container(is_div=True, classes=row_classes)
+        for name, handle in authors:
+            if handle in exclude:
+                continue
+            col = nodes.container(is_div=True, classes=col_classes)
+            card = nodes.container(is_div=True, classes=["card"])
+            card += nodes.image(
+                uri=_get_avatar(handle),
+                alt=f"Profile picture of {name}",
+                classes=["card-img-top"],
+            )
+            card_body = nodes.container(
+                is_div=True, classes=["card-body", "text-center"]
+            )
+            card_title = nodes.paragraph(classes="card-title fs-6 fw-bold".split())
+            card_title += nodes.Text(name)
+            card_body += card_title
+            card_text = nodes.paragraph(classes="card-text text-muted fs-6".split())
+            card_text += nodes.Text("(")
+            card_text += nodes.reference(
+                text=f"@{handle}", refuri=f"https://github.com/{handle}"
+            )
+            card_text += nodes.Text(")")
+            card_body += card_text
+            card += card_body
+            col += card
+            row += col
+        return [row]
+
+
+def setup(app):
+    app.add_directive("fatiando-authors", AuthorsDirective)
+
+    ###########################################################################
+    # Hack from sphinx-panels to make docutils stop inserting the "container"
+    # class into divs (which doesn't play nicely with bootstrap).
+
+    def visit_container(self, node):
+        classes = "docutils container"
+        if node.get("is_div", False):
+            # we don't want the CSS for container for these nodes
+            classes = "docutils"
+        self.body.append(self.starttag(node, "div", CLASS=classes))
+
+    def depart_container(self, node):
+        self.body.append("</div>\n")
+
+    # we override container html visitors, to stop the default behaviour
+    # of adding the `container` class to all nodes.container
+    app.add_node(
+        nodes.container, override=True, html=(visit_container, depart_container)
+    )
+    ###########################################################################
+
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }


### PR DESCRIPTION


<!--
Thank you for contributing a pull request! Please ensure you have taken a look 
at the CONTRIBUTING.md file in this repository (if available) and the general 
guidelines at https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->
**Description**
<!--
Please describe changes proposed and WHY you made them.
-->
Made a sphinx extension (in `sphinx_extensions/authors/__init__.py`) for
fetching the authors for each project and making the cards. This
reuses and replaces the code in `conf.py`, with the advantage of the
download only happening when the page with the list is updated (so
building the docs is much faster now). The extension creates the
`fatiando-authors` directive which creates the list given the name of a
package. This is very specific to our projects so there's no point in
making it a separate package. The code is based on the
sphinx-contributors and takes some code from sphinx-panels extensions
(both MIT licensed). Our extension itself is also licensed MIT for
convenience.


**Relevant issues/PRs**
<!--
Link to relevant issues/PRs. Example: "Fixes #1234" or "See also #345"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
