### PR TITLE
Fix link format for the 2 first buttons on the page

### DIFF
--- a/index.md
+++ b/index.md
@@ -33,20 +33,16 @@ All of our code is **free and open-source**, distributed under the permissive
 [BSD 3-clause license][bsd].
 
 <div class="mt-5">
-  <a href="install">
-    <button type="button" class="btn btn-light mb-3 me-3">
+  <a href="install"><button type="button" class="btn btn-light mb-3 me-3">
       <i class="fab fa-linux"></i>
       <i class="fab fa-apple"></i>
       <i class="fab fa-windows me-2"></i>
       Install
-   </button>
-  </a>
-  <a href="support">
-    <button type="button" class="btn btn-success mb-3">
+  </button></a>
+  <a href="support"><button type="button" class="btn btn-success mb-3">
       <i class="fas fa-people-carry me-2"></i>
       Support the project
-    </button>
-  </a>
+  </button></a>
 </div>
 
 </div> <!-- column -->


### PR DESCRIPTION
Having the `<a>` and `<button>` tags in separate lines made the link
encompass the space between the buttons as well. Fix by having the tags
in the same line.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
