### PR TITLE
Make an extension to add the latest versions

### DIFF
--- a/_static/css/style.css
+++ b/_static/css/style.css
@@ -215,14 +215,12 @@ div.admonition,
   margin: 0 0.25rem;
 }
 
-.project-info {
+.project-info > ul {
   list-style: none;
   padding: 0;
 }
 
-.project-info > li {
-  display: inline-block;
-  margin-right: 1rem;
+.project-info > ul > li {
   line-height: 2;
 }
 

--- a/conf.py
+++ b/conf.py
@@ -15,6 +15,7 @@ sys.path.append(".")
 extensions = [
     "myst_parser",
     "sphinx_extensions.authors",
+    "sphinx_extensions.pypi_version",
 ]
 
 # Sphinx project configuration

--- a/index.md
+++ b/index.md
@@ -176,21 +176,14 @@ Source code for this demonstration:
 Verde offers **spatial** data processing and **interpolation** (gridding) with
 a sprinkling of machine learning.
 
+<div class="project-info">
 
-<ul class="project-info">
-<li>
-  <i class="fa fa-check fa-fw" style="color: green" title="Project status"></i>
-   Stable and ready for use
-</li>
-<li>
-  <i class="fab fa-github fa-fw" title="GitHub repository"></i>
-  <a href="https://github.com/fatiando/verde">fatiando/verde</a>
-</li>
-<li>
-  <i class="fas fa-bookmark fa-fw" title="Publication"></i>
-   doi: <a href="https://doi.org/10.21105/joss.00957">10.21105/joss.00957</a>
-</li>
-</ul>
+* <i class="fa fa-check fa-fw" style="color: green" title="Project status"></i> Stable and ready for use
+* <i class="fab fa-github fa-fw" title="GitHub repository"></i> Code: <a href="https://github.com/fatiando/verde">fatiando/verde</a>
+* <i class="fas fa-box-open fa-fw" title="Latest version"></i> Latest version: {pypi_version}`v<verde>`
+* <i class="fas fa-bookmark fa-fw" title="Publication"></i> doi: <a href="https://doi.org/10.21105/joss.00957">10.21105/joss.00957</a>
+
+</div>
 
 <div class="mt-4">
   <a target="_blank" href="https://www.fatiando.org/verde/">
@@ -226,10 +219,10 @@ without weights based on data uncertainty.
 ## **Pooch:** Easily download datasets
 
 Pooch is the easiest way to **download data files** to your computer.
-
 It is used to manage sample data downloads not only by our own tools but also
 other popular Scientific Python libraries:
 [scikit-image](https://github.com/scikit-image/scikit-image),
+[SciPy](https://github.com/scipy/scipy),
 [MetPy](https://github.com/Unidata/MetPy),
 [xarray](https://github.com/pydata/xarray),
 [SHTOOLS](https://github.com/SHTOOLS/SHTOOLS),
@@ -240,20 +233,14 @@ other popular Scientific Python libraries:
 [napari](https://github.com/napari/napari),
 and [more](https://github.com/fatiando/pooch/network/dependents).
 
-<ul class="project-info">
-<li>
-  <i class="fa fa-check fa-fw" style="color: green" title="Project status"></i>
-   Stable and ready for use
-</li>
-<li>
-  <i class="fab fa-github fa-fw" title="GitHub repository"></i>
-  <a href="https://github.com/fatiando/pooch">fatiando/pooch</a>
-</li>
-<li>
-  <i class="fas fa-bookmark fa-fw" title="Publication"></i>
-   doi: <a href="https://doi.org/10.21105/joss.01943">10.21105/joss.01943</a>
-</li>
-</ul>
+<div class="project-info">
+
+* <i class="fa fa-check fa-fw" style="color: green" title="Project status"></i> Stable and ready for use
+* <i class="fab fa-github fa-fw" title="GitHub repository"></i> Code: <a href="https://github.com/fatiando/pooch">fatiando/pooch</a>
+* <i class="fas fa-box-open fa-fw" title="Latest version"></i> Latest version: {pypi_version}`v<pooch>`
+* <i class="fas fa-bookmark fa-fw" title="Publication"></i> doi: <a href="https://doi.org/10.21105/joss.01943">10.21105/joss.01943</a>
+
+</div>
 
 <div class="mt-4">
   <a target="_blank" href="https://www.fatiando.org/pooch/">
@@ -311,20 +298,14 @@ Our goal is to incentivise good practices by **carefully designing** the
 software and offering **state-of-the-art methods** with efficient
 implementations.
 
-<ul class="project-info">
-<li>
-  <i class="fa fa-sync-alt fa-fw" style="color: orange" title="Project status"></i>
-  Functional but still evolving
-</li>
-<li>
-  <i class="fab fa-github fa-fw" title="GitHub repository"></i>
-  <a href="https://github.com/fatiando/harmonica">fatiando/harmonica</a>
-</li>
-<li>
-  <i class="fas fa-bookmark fa-fw" title="Publication"></i>
-   doi: <a href="https://doi.org/10.5281/zenodo.3628741">10.5281/zenodo.3628741</a>
-</li>
-</ul>
+<div class="project-info">
+
+* <i class="fa fa-sync-alt fa-fw" style="color: orange" title="Project status"></i> Functional but still evolving
+* <i class="fab fa-github fa-fw" title="GitHub repository"></i> Code: <a href="https://github.com/fatiando/harmonica">fatiando/harmonica</a>
+* <i class="fas fa-box-open fa-fw" title="Latest version"></i> Latest version: {pypi_version}`v<harmonica>`
+* <i class="fas fa-bookmark fa-fw" title="Publication"></i> doi: <a href="https://doi.org/10.5281/zenodo.3628741">10.5281/zenodo.3628741</a>
+
+</div>
 
 <div class="mt-4">
   <a target="_blank" href="https://www.fatiando.org/harmonica/">
@@ -361,20 +342,14 @@ gridded to a uniform height with equivalent sources.
 Boule defines **reference ellipsoids** for calculating normal gravity of
 the Earth and other planetary bodies (Moon, Mars, Venus, Mercury).
 
-<ul class="project-info">
-<li>
-  <i class="fa fa-sync-alt fa-fw" style="color: orange" title="Project status"></i>
-  Functional but still evolving
-</li>
-<li>
-  <i class="fab fa-github fa-fw" title="GitHub repository"></i>
-  <a href="https://github.com/fatiando/boule">fatiando/boule</a>
-</li>
-<li>
-  <i class="fas fa-bookmark fa-fw" title="Publication"></i>
-   doi: <a href="https://doi.org/10.5281/zenodo.3530749">10.5281/zenodo.3530749</a>
-</li>
-</ul>
+<div class="project-info">
+
+* <i class="fa fa-sync-alt fa-fw" style="color: orange" title="Project status"></i> Functional but still evolving
+* <i class="fab fa-github fa-fw" title="GitHub repository"></i> Code: <a href="https://github.com/fatiando/boule">fatiando/boule</a>
+* <i class="fas fa-box-open fa-fw" title="Latest version"></i> Latest version: {pypi_version}`v<boule>`
+* <i class="fas fa-bookmark fa-fw" title="Publication"></i> doi: <a href="https://doi.org/10.5281/zenodo.3530749">10.5281/zenodo.3530749</a>
+
+</div>
 
 <div class="mt-4">
   <a target="_blank" href="https://www.fatiando.org/boule/">
@@ -412,20 +387,14 @@ Ensaio makes it easy to download our open-access **sample datasets**. It taps
 into the [Fatiando a Terra FAIR data collection](https://github.com/fatiando-data)
 which is designed for use in tutorials, documentation, and teaching.
 
-<ul class="project-info">
-<li>
-  <i class="fa fa-sync-alt fa-fw" style="color: orange" title="Project status"></i>
-  Functional but still evolving
-</li>
-<li>
-  <i class="fab fa-github fa-fw" title="GitHub repository"></i>
-  <a href="https://github.com/fatiando/ensaio">fatiando/ensaio</a>
-</li>
-<li>
-  <i class="fas fa-bookmark fa-fw" title="Publication"></i>
-   doi: <a href="https://doi.org/10.5281/zenodo.5784202">10.5281/zenodo.5784202</a>
-</li>
-</ul>
+<div class="project-info">
+
+* <i class="fa fa-sync-alt fa-fw" style="color: orange" title="Project status"></i> Functional but still evolving
+* <i class="fab fa-github fa-fw" title="GitHub repository"></i> Code: <a href="https://github.com/fatiando/ensaio">fatiando/ensaio</a>
+* <i class="fas fa-box-open fa-fw" title="Latest version"></i> Latest version: {pypi_version}`v<ensaio>`
+* <i class="fas fa-bookmark fa-fw" title="Publication"></i> doi: <a href="https://doi.org/10.5281/zenodo.5784202">10.5281/zenodo.5784202</a>
+
+</div>
 
 <div class="mt-4">
   <a target="_blank" href="https://www.fatiando.org/ensaio/">
@@ -521,18 +490,6 @@ Happy community members at a [Fatiando Community Call](https://youtu.be/gsYKW7XN
 
 </div>
 </div> <!-- row -->
-
-<!--<h2 class="text-center fs-4">Releases</h2>-->
-<div class="text-center">
-
-**Latest releases:**
-<a href="https://pypi.python.org/pypi/pooch"><img class="shield" alt="Pooch latest version" src="https://img.shields.io/pypi/v/pooch.svg?style=flat-square&label=Pooch"></a>
-<a href="https://pypi.python.org/pypi/verde"><img class="shield" alt="Verde latest version" src="https://img.shields.io/pypi/v/verde.svg?style=flat-square&label=Verde"></a>
-<a href="https://pypi.python.org/pypi/harmonica"><img class="shield" alt="Harmonica latest version" src="https://img.shields.io/pypi/v/harmonica.svg?style=flat-square&label=Harmonica"></a>
-<a href="https://pypi.python.org/pypi/boule"><img class="shield" alt="Boule latest version" src="https://img.shields.io/pypi/v/boule.svg?style=flat-square&label=Boule"></a>
-<a href="https://pypi.python.org/pypi/ensaio"><img class="shield" alt="ensaio latest version" src="https://img.shields.io/pypi/v/ensaio.svg?style=flat-square&label=ensaio"></a>
-
-</div>
 
 </div> <!-- container -->
 </div> <!-- container-fluid -->

--- a/sphinx_extensions/pypi_version/__init__.py
+++ b/sphinx_extensions/pypi_version/__init__.py
@@ -1,0 +1,47 @@
+"""
+Sphinx extension for inserting a link to the latest release on PyPI
+"""
+import re
+import json
+import requests
+import packaging.version
+from docutils import nodes
+
+__version__ = "0.1.0"
+
+
+def pypi_version(name, rawtext, text, lineno, inliner, options=None, content=None):
+    """
+    Create a link to the latest version of a package on PyPI.
+
+    The text for the role should be "package" or "text <package>". The package
+    name or "<package>" will be replaced by the latest version number.
+    """
+    arguments = re.findall(r"\<(.+?)\>", text)
+    if len(arguments) > 1:
+        raise ValueError("Invalid pypi_version role: rawtext")
+    elif arguments:
+        package = arguments[0]
+        placeholder = f"<{package}>"
+    else:
+        package = text
+        placeholder = package
+    url = f"https://pypi.org/pypi/{package}/json"
+    response = requests.get(url)
+    response.raise_for_status()
+    releases = [
+        packaging.version.parse(v)
+        for v in json.loads(response.text).get("releases", [])
+    ]
+    version = max(releases)
+    node = nodes.reference(
+        text=text.replace(placeholder, str(version)),
+        refuri=f"https://pypi.org/project/{package}",
+    )
+    return [node], []
+
+
+def setup(app):
+    "Register the new role with sphinx"
+    app.add_role("pypi_version", pypi_version)
+    return {"version": __version__}


### PR DESCRIPTION
In the list of info for each package, we now add a link to the latest
version (including the version number). Before we had these as
shields.io badges at the bottom but they were a bit hidden and looked
out of place in the info list. The extension queries the PyPI API to get
the latest version and inserts a link to it with the version number as
the text.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
