### PR TITLE
Replace slack links with Matrix/Swung

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -21,42 +21,7 @@ development, and make friends along the way.
 The Fatiando community gathers in a few different places, **all of which are
 completely open to everyone**.
 So come along and join the conversation!
-
-### Text-based
-
-Asynchronous communication for anything from technical discussions to random
-chat:
-
-<ul class="fa-ul">
-<li>
-
-<i class="fa-li fab fa-slack fa-fw"></i>
-<a href="/slack">Slack</a>: this is where we ask and answer questions, organize
-meetings and events, share news, chat, etc.
-
-</li>
-<li>
-
-<i class="fa-li fab fa-github fa-fw"></i>
-[GitHub][gh]:
-where we discuss development details, review code, etc.
-
-</li>
-</ul>
-
-### Video calls
-
-Synchronous online calls to tackle topics when text-based discussion becomes
-inefficient and mostly get to know each other better.
-
-We **meet up weekly** to discuss project development, get to know each other,
-share experiences, and even code things live to show our process. They are a
-great way to learn more about day-to-day development and get to know our global
-community. It's absolutely fine to join and just listen to what we discuss but
-we welcome participation!
-
-Dates, connection details, agendas, and past notes from meetings are available
-in the <i class="fab fa-github"></i> [`fatiando/community`][notes] repository.
+See {ref}`contact` to find out where we gather.
 
 ## <i class="fa fa-cog"></i> Join the development
 

--- a/conf.py
+++ b/conf.py
@@ -59,11 +59,6 @@ html_context = {
             "https://github.com/fatiando",
         ),
         (
-            "fab fa-slack",
-            "Slack",
-            "/slack",
-        ),
-        (
             "fab fa-twitter",
             "Twitter",
             "https://twitter.com/fatiandoaterra",

--- a/contact/index.md
+++ b/contact/index.md
@@ -7,23 +7,35 @@ Your input is welcome and appreciated.
 <strong>Get in touch!</strong>
 </p>
 
-<div class="row text-center gy-5">
+<div class="row text-center gy-5  justify-content-md-center">
 <div class="col-sm-6">
 
-<i class="fab fa-slack fa-4x"></i>
+<i class="fas fa-comments fa-4x"></i>
 <h2 class="no-top-margin">Chat</h2>
 
-Hop on to our [Slack chat room][slack] to **talk to users and developers**,
-participate in our video calls, and get to know the community.
+Hop on to our [Matrix chat room][matrix] or the `#fatiando` channel in the
+[Software Underground Slack][slack] to **talk to users and developers**
+and get to know the community.
 
 </div>
 <div class="col-sm-6">
 
-<i class="fas fa-comments fa-4x"></i>
+<i class="fas fa-question-circle fa-4x"></i>
 <h2 class="no-top-margin">Forum</h2>
 
 Participate in the [Fatiando community forum][forum] to **ask and answer
 questions**, get project updates, share your expertise, and showcase your work.
+
+</div>
+<div class="col-sm-6">
+
+<i class="fas fa-microphone-alt fa-4x"></i>
+<h2 class="no-top-margin">Video calls</h2>
+
+We meet up weekly to discuss project development and share updates.
+**Everyone is welcome to participate!**
+Dates and connection details are in <i class="fab fa-github"></i>
+[`fatiando/community`][notes].
 
 </div>
 <div class="col-sm-6">
@@ -49,7 +61,9 @@ and updates** about the project.
 
 [linkedin]: https://www.linkedin.com/company/fatiando
 [twitter]: https://twitter.com/fatiandoaterra
-[slack]: https://www.fatiando.org/slack
+[slack]: https://softwareunderground.org/slack
+[matrix]: https://matrix.to/#/#fatiando-a-terra:matrix.org
 [forum]: https://github.com/orgs/fatiando/discussions
 [gh]: https://github.com/fatiando
 [bug-report]: https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
+[notes]: https://github.com/fatiando/community

--- a/forward/slack/index.html
+++ b/forward/slack/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv="Refresh" content="0;url=https://join.slack.com/t/fatiando/shared_invite/enQtNzY4NDQ3ODQwNDk4LTc5MTU5OWNkNTczMDY4NjcyNjcyZTU0Y2I3MDQ0NWUwMmEzMTBkNmVjNTExMGZkMjA0YzM1OGYyMzZlMDk3YTU"/>
+<meta http-equiv="Refresh" content="0;url=https://softwareunderground.org/slack"/>


### PR DESCRIPTION
We're now using a channel on matrix that's mirrored to the #fatiando
channel on Software Underground. Update the links in the contact page to
these two places instead. Also move the video call information to the
contact page and remove duplicated content from the community page.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:** Fixes #61 
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
