### PR TITLE
Add a link to the plausible dashboard in the footer

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -41,7 +41,7 @@
   <meta property="og:description" content="{{ description }}">
 
   <!-- Plausible analytics for anonymous usage statistics -->
-  <script defer data-domain="fatiando.org" src="https://plausible.io/js/plausible.js"></script>
+  {{ plausible }}
 
   {%- block extrahead %}{% endblock %}
 </head>
@@ -104,12 +104,16 @@
         (commit
         <a href="https://github.com/{{ repository }}/commit/{{ commit }}"><code>{{ commit }}</code></a>)
         <span class="bullet-separator">&bull;</span>
-        Source code at
-        <a href="https://github.com/{{ repository }}">
-          <code>{{ repository }}</code>
-        </a>
-        <span class="bullet-separator">&bull;</span>
         Created using <a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}
+        <span class="bullet-separator">&bull;</span>
+        Source code for this website:
+        <a href="https://github.com/{{ repository }}">
+           <i class="fab fa-github ms-1"></i> <code>{{ repository }}</code>
+        </a>
+      </p>
+      <p>
+        Annonymous visitor statistics for this website are publicly available at
+        <a href="{{ plausible_dashboard }}"><code>{{ plausible_dashboard }}</code></a>
       </p>
       <p>
         Copyright &copy; {{ copyright }}.

--- a/conf.py
+++ b/conf.py
@@ -88,6 +88,8 @@ html_context = {
         text=True,
     ).stdout.strip(),
     "repository": "fatiando/website",
+    "plausible": '<script defer data-domain="fatiando.org" src="https://plausible.io/js/plausible.js"></script>',
+    "plausible_dashboard": "https://plausible.io/fatiando.org",
     "last_updated": str(current_date),
     "navbar_brand": "_static/fatiando-logo.svg",
     "stylesheet": "css/style.css",


### PR DESCRIPTION
Mention that the visitor statistics are publicly available and provide
the dashboard address. Helps with transparency but there is no need for
a whole page on the website just for this.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
