### PR TITLE
Add missing link to Ensaio docs in Learn page

### DIFF
--- a/learn/index.md
+++ b/learn/index.md
@@ -80,9 +80,15 @@ Harmonica
 </button></a>
 
 <a target="_blank" href="https://www.fatiando.org/boule">
-<button type="button" class="btn btn-secondary mb-3">
+<button type="button" class="btn btn-secondary mb-3 me-3">
 <i class="fa fa-book"></i>
 Boule
+</button></a>
+
+<a target="_blank" href="https://www.fatiando.org/ensaio">
+<button type="button" class="btn btn-secondary mb-3">
+<i class="fa fa-book"></i>
+Ensaio
 </button></a>
 
 </div>


### PR DESCRIPTION
We forgot to add a little button there with the link to the docs



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
