### PR TITLE
Remove the 2022 survey alert since it's now closed

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -88,10 +88,5 @@ html_context = {
     "last_updated": str(current_date),
     "navbar_brand": "_static/fatiando-logo.svg",
     "stylesheet": "css/style.css",
-    "alerts": [
-        (
-            '<i class="fas fa-poll me-1"></i> The <strong>Fatiando Community Survey</strong> 2022 is now open! Please take 5-10 minutes to <a class="alert-link" target="_blank" href="https://forms.gle/EB4VFLY8PYb7UoJSA">fill it out <i class="fa fa-external-link-square-alt ms-1"></i></a>.',
-            "warning",
-        ),
-    ],
+    "alerts": [],
 }


### PR DESCRIPTION
Leave the page without one for now to make sure people notice it when it goes back up (otherwise it's a permanent part of the page and people ignore it).



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
