### PR TITLE
Add our Mastodon account to the menu and Contact

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -71,7 +71,7 @@
           {%- endfor %}
           {%- for link in social_links %}
             <li class="nav-item">
-              <a class="nav-link" href="{{ link[2] }}" target="_blank"><i class="{{ link[0] }}" title="{{ link[1] }}" alt="{{ link[1] }}"></i></a>
+              <a rel="me" class="nav-link" href="{{ link[2] }}" target="_blank"><i class="{{ link[0] }}" title="{{ link[1] }}" alt="{{ link[1] }}"></i></a>
             </li>
           {%- endfor %}
         </ul>

--- a/conf.py
+++ b/conf.py
@@ -59,6 +59,11 @@ html_context = {
             "https://github.com/fatiando",
         ),
         (
+            "fab fa-mastodon",
+            "Mastodon",
+            "https://fosstodon.org/@fatiando",
+        ),
+        (
             "fab fa-twitter",
             "Twitter",
             "https://twitter.com/fatiandoaterra",

--- a/contact/index.md
+++ b/contact/index.md
@@ -29,6 +29,18 @@ questions**, get project updates, share your expertise, and showcase your work.
 </div>
 <div class="col-sm-6">
 
+<i class="fas fa-share-alt fa-4x"></i>
+<h2 class="no-top-margin">Social media</h2>
+
+Do you want regular **news and updates** about the project?
+Follow Fatiando on
+<i class="fab fa-mastodon" aria-hidden="true"></i> [Mastodon][mastodon],
+<i class="fab fa-linkedin" aria-hidden="true"></i> [LinkedIn][linkedin],
+and <i class="fab fa-twitter" aria-hidden="true"></i> [Twitter][twitter].
+
+</div>
+<div class="col-sm-6">
+
 <i class="fas fa-microphone-alt fa-4x"></i>
 <h2 class="no-top-margin">Video calls</h2>
 
@@ -48,17 +60,9 @@ To **report bugs** and **request features**, [open an Issue][bug-report] on
 Leave a comment on any issue or pull request to join the conversation.
 
 </div>
-<div class="col-sm-6">
-
-<i class="fab fa-twitter fa-4x"></i>
-<h2 class="no-top-margin">Updates</h2>
-
-Follow us on [LinkedIn][linkedin] and [Twitter][twitter] where we post **news
-and updates** about the project.
-
-</div>
 </div>
 
+[mastodon]: https://fosstodon.org/@fatiando
 [linkedin]: https://www.linkedin.com/company/fatiando
 [twitter]: https://twitter.com/fatiandoaterra
 [slack]: https://softwareunderground.org/slack


### PR DESCRIPTION
Had to edit the template to include the `rel="me"` attribute in the social media links. This is used to verify that the owner of the website and social media account are the same person. Make the social media section of the Contact page more generic ("Social media" instead of "Updates" and use a different icon than the twitter bird). Move it up a bit since it was kind of hidden as the last element of that page.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
