### PR TITLE
Fix link to Mattermost channel

### DIFF
--- a/contact/index.md
+++ b/contact/index.md
@@ -65,7 +65,7 @@ Leave a comment on any issue or pull request to join the conversation.
 [mastodon]: https://fosstodon.org/@fatiando
 [linkedin]: https://www.linkedin.com/company/fatiando
 [twitter]: https://twitter.com/fatiandoaterra
-[fatiando-channel]: https://mattermost.softwareunderground.org/software-underground/channels/fatiando
+[fatiando-channel]: https://mattermost.softwareunderground.org/swung/channels/fatiando
 [swung-mattermost]: https://mattermost.softwareunderground.org
 [forum]: https://github.com/orgs/fatiando/discussions
 [gh]: https://github.com/fatiando


### PR DESCRIPTION
Fix the link to the `~fatiando` channel in Swung's Mattermost after they renamed the Team.

**Relevant issues/PRs:**

Issue raised in https://github.com/orgs/fatiando/discussions/130
