### PR TITLE
Persist credentials to fix the deployment process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # The GitHub token is preserved by default but this job doesn't need
-          # to be able to push to GitHub.
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Try to persist credentials when checking out the repo to see if that
solves the lack of permissions when deploying the website.
