### PR TITLE
Leave default permissions in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,19 +11,13 @@ on:
     - cron:  '00 12 * * 1'
   workflow_dispatch:
 
-permissions: {}
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          persist-credentials: true
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Try to see if the deployment failure is related to explicitly setting
permissions.
